### PR TITLE
feat: Ignore unsupported kitty config files in ftdetect

### DIFF
--- a/ftdetect/kitty.lua
+++ b/ftdetect/kitty.lua
@@ -2,7 +2,8 @@
 	Filetype detection for config files of `kitty`.
 	Language:          kitty
 	Maintainer:        MD. Mouinul Hossain Shawon
-	Last Change:       9 September, 2025
+	Last Change:       19 February, 2026
+	URL:               https://github.com/OXY2DEV/tree-sitter-kitty/blob/main/ftdetect/kitty.lua
 ]]
 
 

--- a/ftdetect/kitty.lua
+++ b/ftdetect/kitty.lua
@@ -33,6 +33,21 @@ vim.api.nvim_create_autocmd({
 			get_kitty_config_dir()
 		);
 
+		-- theme.conf files work OK
+		local unsupported = {
+			"open%-actions%.conf$",
+			"launch%-actions%.conf$",
+			"diff%.conf$",
+			"ssh%.conf$",
+			"choose%-files%.conf$",
+			"quick%-access%-terminal%.conf$",
+		}
+		for i = 1, #unsupported do
+			if string.match(path, unsupported[i]) then
+				return
+			end
+		end
+
 		if
 			string.match(path, kitty_config_path) or
 			string.match(path, "kitty%.conf$")


### PR DESCRIPTION
The other kitty configuration files have additional syntax that isn't yet supported.

<img width="295" height="135" alt="kitty" src="https://github.com/user-attachments/assets/9f666af4-46a2-45de-8c07-d29b6f07905c" />


So, recognize and avoid them in the ftdetect script.